### PR TITLE
Fix display of parse errors

### DIFF
--- a/lib/yaml/sort/cli.rb
+++ b/lib/yaml/sort/cli.rb
@@ -52,7 +52,7 @@ module Yaml
 
       def process_document(filename, options)
         yaml = read_document(filename)
-        sorted_yaml = sort_yaml(yaml)
+        sorted_yaml = sort_yaml(yaml, filename)
         write_output(yaml, sorted_yaml, filename, options)
       end
 
@@ -64,8 +64,8 @@ module Yaml
         end
       end
 
-      def sort_yaml(yaml)
-        document = @parser.parse(yaml)
+      def sort_yaml(yaml, filename)
+        document = @parser.parse(yaml, filename: filename)
         document = document.sort
         "---\n#{document}\n"
       end

--- a/lib/yaml/sort/parser.ra
+++ b/lib/yaml/sort/parser.ra
@@ -171,7 +171,8 @@ def next_token
   @current_token = @tokens.shift
 end
 
-def parse(text)
+def parse(text, filename: nil)
+  @filename = filename
   scan(text)
   do_parse
 end


### PR DESCRIPTION
On parse error, the error location is printed as filename:line, but the
filename was never set and always displayed <stdin>:line, even when
given a filename.
