### PR TITLE
Fix error reporting

### DIFF
--- a/features/error_reporting.feature
+++ b/features/error_reporting.feature
@@ -1,0 +1,70 @@
+Feature: Error reporting
+  Scenario: Invalid file content with unexpected key
+    Given a file named "sample.yaml" with:
+      """
+      ---
+      - baz
+
+
+
+      foo: bar
+
+      """
+    When I run `exe/yaml-sort sample.yaml`
+    Then the stderr should contain:
+      """
+      sample.yaml:6 unexpected KEY
+      foo: bar
+      ^~~~
+      """
+
+  Scenario: Invalid file content with unexpected list item
+    Given a file named "sample.yaml" with:
+      """
+      ---
+
+
+
+
+      foo: bar
+      - baz
+      """
+    When I run `exe/yaml-sort sample.yaml`
+    Then the stderr should contain:
+      """
+      sample.yaml:7 unexpected ITEM
+      - baz
+      ^~
+      """
+
+  Scenario: Invalid file content with unexpected end-of-file
+    Given a file named "sample.yaml" with:
+      """
+      ---
+
+
+      foo:
+
+      """
+    When I run `exe/yaml-sort sample.yaml`
+    Then the stderr should contain:
+      """
+      sample.yaml:4 unexpected UNINDENT
+      foo:
+      ^
+      """
+
+  Scenario: Invalid file content with unexpected end-of-file
+    Given a file named "sample.yaml" with:
+      """
+      ---
+
+
+
+
+      """
+    When I run `exe/yaml-sort sample.yaml`
+    Then the stderr should contain:
+      """
+      sample.yaml:4 unexpected end-of-file
+      """

--- a/lib/yaml/sort/cli.rb
+++ b/lib/yaml/sort/cli.rb
@@ -54,6 +54,9 @@ module Yaml
         yaml = read_document(filename)
         sorted_yaml = sort_yaml(yaml, filename)
         write_output(yaml, sorted_yaml, filename, options)
+      rescue Racc::ParseError => e
+        warn(e.message)
+        @exit_code = 1
       end
 
       def read_document(filename)

--- a/lib/yaml/sort/parser.ra
+++ b/lib/yaml/sort/parser.ra
@@ -46,7 +46,7 @@ def scan(text)
   until s.eos?
     if scan_value
       unless s.match?(/[[:space:]]*\n/)
-        @position += s.matched_size if s.scan(/\s*/)
+        @position += s.matched_size if s.scan(/[[:blank:]]*/)
         case
         when s.scan(/[|>][-+]?(?=\n)/)
           match = s.matched
@@ -85,20 +85,23 @@ def scan(text)
       scan_value = false
     else
       case
-      when s.scan(/---/)              then emit(:START_OF_DOCUMENT, s.matched)
-      when s.scan(/(\n\s*)+(?=\n)/)   then # Ignore empty lines
-      when s.scan(/\n?\s*#.*/)        then emit(:COMMENT, s.matched)
-      when s.scan(/\n?(\s*-) */)      then emit("-", s.matched, indent: s.captures[0])
-      when s.scan(/\n?\s*\.\.\./)     then emit(:END_OF_DOCUMENT, s.matched)
-      when s.scan(/\n?(\s*)([^[[:space:]]\n]+):(?=[ \n])/)
+      when s.scan(/---/)                    then emit(:START_OF_DOCUMENT, s.matched)
+      when s.scan(/\n[[:blank:]]*(?=\n)/)
+        # Ignore empty lines
+        @lineno += 1
+        @position = 0
+      when s.scan(/\n[[:blank:]]*#.*/)      then emit(:COMMENT, s.matched)
+      when s.scan(/\n([[:blank:]]*-) */)    then emit("-", s.matched, indent: s.captures[0])
+      when s.scan(/\n[[:blank:]]*\.\.\./)   then emit(:END_OF_DOCUMENT, s.matched)
+      when s.scan(/\n?([[:blank:]]*)([^[[:space:]]\n]+):(?=[ \n])/)
         indent = s.captures[0]
         indent = last_indent_value + indent + " " unless s.matched.start_with?("\n")
         emit(:KEY, s.matched, indent: indent)
 
       when s.scan(/\n\z/)
         # Done
-     when s.match?(/./)
-       scan_value = true
+      when s.match?(/./)
+        scan_value = true
       else
         raise "LoST: #{s.rest.inspect} #{s.eos?}"
       end

--- a/lib/yaml/sort/parser.ra
+++ b/lib/yaml/sort/parser.ra
@@ -145,7 +145,6 @@ def emit(token, value, length: nil, indent: nil)
     value: value,
     lineno: @lineno,
     position: @position,
-    filename: @filename,
     length: length,
     indent: indent,
   }
@@ -163,7 +162,7 @@ end
 def unindent(new_indent = nil)
   while @indent_stack.count > 0 && (new_indent.nil? || @indent_stack.last.length > new_indent.length)
     value = @indent_stack.pop
-    @tokens << [:UNINDENT, { value: value, lineno: @lineno, position: 0, filename: @filename, length: value.length, indent: nil }]
+    @tokens << [:UNINDENT, { value: value, lineno: @lineno, position: 0, length: value.length, indent: nil }]
   end
 end
 
@@ -172,15 +171,21 @@ def next_token
 end
 
 def parse(text, filename: nil)
-  @filename = filename
+  @filename = filename || "<stdin>"
   scan(text)
   do_parse
 end
 
 def on_error(error_token_id, error_value, value_stack)
-  puts "unexpected #{@current_token[0]} on #{@current_token[1][:filename] || "<stdin>"}:#{@current_token[1][:lineno]}"
-  puts @lines[@current_token[1][:lineno]]
-  puts " " * @current_token[1][:position] + "^" + "~" * (@current_token[1][:length] - 1)
+  message = if @current_token
+              <<~MESSAGE
+                #{@filename}:#{@current_token[1][:lineno]} unexpected #{@current_token[0]}
+                #{@lines[@current_token[1][:lineno] - 1].chomp}
+                #{" " * @current_token[1][:position]}^#{"~" * ([@current_token[1][:length] - 1, 0].max)}
+                MESSAGE
+            else
+              "#{@filename}:#{@lineno} unexpected end-of-file"
+            end
 
-  raise "Error"
+  raise(Racc::ParseError, message)
 end

--- a/lib/yaml/sort/parser.ra
+++ b/lib/yaml/sort/parser.ra
@@ -5,7 +5,7 @@
 class Yaml::Sort::Parser
 token
   START_OF_DOCUMENT END_OF_DOCUMENT
-  VALUE KEY UNINDENT
+  VALUE KEY UNINDENT ITEM
 rule
   document: START_OF_DOCUMENT value END_OF_DOCUMENT { result = val[1] }
           | START_OF_DOCUMENT value                 { result = val[1] }
@@ -23,7 +23,7 @@ rule
   list: list list_item { val[0].add_item(*val[1]); result = val[0] }
       | list_item      { result = List.create(*val[0]) }
 
-  list_item: '-' value { result = [Scalar.new(val[0]), val[1]] }
+  list_item: ITEM value { result = [Scalar.new(val[0]), val[1]] }
 end
 
 ---- header
@@ -91,7 +91,7 @@ def scan(text)
         @lineno += 1
         @position = 0
       when s.scan(/\n[[:blank:]]*#.*/)      then emit(:COMMENT, s.matched)
-      when s.scan(/\n([[:blank:]]*-) */)    then emit("-", s.matched, indent: s.captures[0])
+      when s.scan(/\n([[:blank:]]*-) */)    then emit(:ITEM, s.matched, indent: s.captures[0])
       when s.scan(/\n[[:blank:]]*\.\.\./)   then emit(:END_OF_DOCUMENT, s.matched)
       when s.scan(/\n?([[:blank:]]*)([^[[:space:]]\n]+):(?=[ \n])/)
         indent = s.captures[0]

--- a/spec/yaml/sort_parser_spec.rb
+++ b/spec/yaml/sort_parser_spec.rb
@@ -21,14 +21,14 @@ RSpec.describe Yaml::Sort::Parser do
     subject { Yaml::Sort::Parser.new.scan(document) }
 
     it do
-      is_expected.to eq([[:START_OF_DOCUMENT, { filename: nil, length: 3, lineno: 1, position: 0, value: "---", indent: nil }],
-                         [:KEY, { filename: nil, length: 4, lineno: 2, position: 0, value: "foo:", indent: "" }],
-                         [:VALUE, { filename: nil, length: 3, lineno: 2, position: 5, value: "bar", indent: nil }],
-                         [:KEY, { filename: nil, length: 4, lineno: 3, position: 0, value: "bar:", indent: "" }],
-                         [:VALUE, { filename: nil, length: 9, lineno: 3, position: 5, value: "|-\n  Plop", indent: nil }],
-                         [:KEY, { filename: nil, length: 4, lineno: 5, position: 0, value: "baz:", indent: "" }],
-                         [:VALUE, { filename: nil, length: 2, lineno: 5, position: 5, value: "42", indent: nil }],
-                         [:UNINDENT, { filename: nil, length: 0, lineno: 5, position: 0, value: "", indent: nil }]])
+      is_expected.to eq([[:START_OF_DOCUMENT, { length: 3, lineno: 1, position: 0, value: "---", indent: nil }],
+                         [:KEY, { length: 4, lineno: 2, position: 0, value: "foo:", indent: "" }],
+                         [:VALUE, { length: 3, lineno: 2, position: 5, value: "bar", indent: nil }],
+                         [:KEY, { length: 4, lineno: 3, position: 0, value: "bar:", indent: "" }],
+                         [:VALUE, { length: 9, lineno: 3, position: 5, value: "|-\n  Plop", indent: nil }],
+                         [:KEY, { length: 4, lineno: 5, position: 0, value: "baz:", indent: "" }],
+                         [:VALUE, { length: 2, lineno: 5, position: 5, value: "42", indent: nil }],
+                         [:UNINDENT, { length: 0, lineno: 5, position: 0, value: "", indent: nil }]])
     end
   end
 

--- a/spec/yaml/sort_parser_spec.rb
+++ b/spec/yaml/sort_parser_spec.rb
@@ -175,14 +175,14 @@ RSpec.describe Yaml::Sort::Parser do
     context "#scan" do
       subject { Yaml::Sort::Parser.new.scan(document).map(&:first) }
       it do
-        is_expected.to eq([:START_OF_DOCUMENT,
-                           "-",
-                           :VALUE,
-                           "-",
-                           :VALUE,
-                           "-",
-                           :VALUE,
-                           :UNINDENT])
+        is_expected.to eq(%i[START_OF_DOCUMENT
+                             ITEM
+                             VALUE
+                             ITEM
+                             VALUE
+                             ITEM
+                             VALUE
+                             UNINDENT])
       end
     end
   end
@@ -202,18 +202,18 @@ RSpec.describe Yaml::Sort::Parser do
     context "#scan" do
       subject { Yaml::Sort::Parser.new.scan(document).map(&:first) }
       it do
-        is_expected.to eq([:START_OF_DOCUMENT,
-                           "-",
-                           :KEY,
-                           :VALUE,
-                           :KEY,
-                           :VALUE,
-                           :UNINDENT,
-                           "-",
-                           :KEY,
-                           :VALUE,
-                           :UNINDENT,
-                           :UNINDENT])
+        is_expected.to eq(%i[START_OF_DOCUMENT
+                             ITEM
+                             KEY
+                             VALUE
+                             KEY
+                             VALUE
+                             UNINDENT
+                             ITEM
+                             KEY
+                             VALUE
+                             UNINDENT
+                             UNINDENT])
       end
     end
   end
@@ -234,16 +234,16 @@ RSpec.describe Yaml::Sort::Parser do
     context "#scan" do
       subject { Yaml::Sort::Parser.new.scan(document).map(&:first) }
       it do
-        is_expected.to eq([:START_OF_DOCUMENT,
-                           :KEY,
-                           "-",
-                           :VALUE,
-                           "-",
-                           :VALUE,
-                           "-",
-                           :VALUE,
-                           :UNINDENT,
-                           :UNINDENT])
+        is_expected.to eq(%i[START_OF_DOCUMENT
+                             KEY
+                             ITEM
+                             VALUE
+                             ITEM
+                             VALUE
+                             ITEM
+                             VALUE
+                             UNINDENT
+                             UNINDENT])
       end
     end
   end
@@ -269,16 +269,16 @@ RSpec.describe Yaml::Sort::Parser do
     context "#scan" do
       subject { Yaml::Sort::Parser.new.scan(document).map(&:first) }
       it do
-        is_expected.to eq([:START_OF_DOCUMENT,
-                           :KEY,
-                           "-",
-                           :VALUE,
-                           "-",
-                           :VALUE,
-                           "-",
-                           :VALUE,
-                           :UNINDENT,
-                           :UNINDENT])
+        is_expected.to eq(%i[START_OF_DOCUMENT
+                             KEY
+                             ITEM
+                             VALUE
+                             ITEM
+                             VALUE
+                             ITEM
+                             VALUE
+                             UNINDENT
+                             UNINDENT])
       end
     end
   end


### PR DESCRIPTION
Error reporting is somewhat broken.  Some valid documents raise errors that are not properly formatted for the end-user (e.g. #3).
