### PR TITLE
Fix processing some YAML files without START_OF_DOCUMENT

### DIFF
--- a/lib/yaml/sort/parser.ra
+++ b/lib/yaml/sort/parser.ra
@@ -9,7 +9,6 @@ token
 rule
   document: START_OF_DOCUMENT value END_OF_DOCUMENT { result = val[1] }
           | START_OF_DOCUMENT value                 { result = val[1] }
-          | value
 
   value: VALUE               { result = Scalar.new(val[0]) }
        | dictionary UNINDENT { result = val[0] }
@@ -33,6 +32,8 @@ require 'strscan'
 ---- inner
 
 def scan(text)
+  text = "---\n#{text}" unless text.start_with?("---\n")
+
   scan_value = false
 
   @lines = text.lines


### PR DESCRIPTION
The parser relies on the `\n` that precedes most items to process the
documents.  A YAML file without the `---\n` prevents the system to be
able to detect the first item, leading to inconsistent parsing.

Automatically prepend a start of document if none is found when reading
the YAML file, and mandate the presence of the START_OF_DOCUMENT token
in the parser.

Fixes #3
