### PR TITLE
Rework list sorting

### DIFF
--- a/features/sort.feature
+++ b/features/sort.feature
@@ -16,6 +16,8 @@ Feature: Sorting YAML files
       foo: foo
       """
   Scenario: Sorting lists by value
+    For now, scalars are not sorted.  At some point, we want to add a flag or
+    controll comments to indicate some lists of scalars need to be sorted.
     Given a file named "list.yaml" with:
       """
       ---
@@ -27,9 +29,9 @@ Feature: Sorting YAML files
     Then the stdout should contain:
       """
       ---
+      - foo
       - bar
       - baz
-      - foo
       """
   Scenario: Sorting Puppet hiera data
     The `lookup_options` key is special, we want it to always be at the
@@ -58,9 +60,9 @@ Feature: Sorting YAML files
         "profile::acme::secret":
           convert_to: "Sensitive"
       classes:
+      - foo
       - bar
       - baz
-      - foo
       profile::acme::secret: password
       """
   Scenario: Preserving comments
@@ -87,11 +89,11 @@ Feature: Sorting YAML files
       # (Just like a single-line comment)
       bar: bar
       baz:
+        # Single line
+        - foo
         # Multi
         # line
         - bar
-        # Single line
-        - foo
       # A single-line comment is attached to the following item
       foo: foo
       """

--- a/features/sort.feature
+++ b/features/sort.feature
@@ -33,6 +33,30 @@ Feature: Sorting YAML files
       - bar
       - baz
       """
+  Scenario: Sorting nested lists and dictionaries
+    Given a file named "sample.yaml" with:
+      """
+      ---
+      items:
+      - foo: 1
+        bar: 2
+        baz: 3
+      - toto: 4
+        tata: 5
+        titi: 6
+      """
+    When I successfully run `exe/yaml-sort sample.yaml`
+    Then the stdout should contain:
+      """
+      ---
+      items:
+      - bar: 2
+        baz: 3
+        foo: 1
+      - tata: 5
+        titi: 6
+        toto: 4
+      """
   Scenario: Sorting Puppet hiera data
     The `lookup_options` key is special, we want it to always be at the
     beginning of the file.

--- a/lib/yaml/sort.rb
+++ b/lib/yaml/sort.rb
@@ -3,6 +3,7 @@
 require_relative "sort/parser"
 require_relative "sort/value"
 require_relative "sort/dictionary"
+require_relative "sort/item"
 require_relative "sort/list"
 require_relative "sort/scalar"
 require_relative "sort/version"

--- a/lib/yaml/sort/dictionary.rb
+++ b/lib/yaml/sort/dictionary.rb
@@ -20,13 +20,15 @@ module Yaml
         dict
       end
 
-      def to_s
+      def to_s(skip_first_indent: false)
+        n = -1
         super + items.map do |k, v|
+          n += 1
           case v
           when List, Dictionary
-            "#{k}\n#{v}"
+            "#{k.to_s(skip_first_indent: skip_first_indent && n.zero?)}\n#{v}"
           when Scalar
-            "#{k} #{v}"
+            "#{k.to_s(skip_first_indent: skip_first_indent && n.zero?)} #{v}"
           end
         end.join("\n")
       end

--- a/lib/yaml/sort/item.rb
+++ b/lib/yaml/sort/item.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+require_relative "scalar"
+
+module Yaml
+  module Sort
+    class Item < Scalar
+      def to_s(*)
+        comments + value
+      end
+    end
+  end
+end

--- a/lib/yaml/sort/list.rb
+++ b/lib/yaml/sort/list.rb
@@ -27,9 +27,6 @@ module Yaml
       end
 
       def sort
-        List.new(items.sort { |a, b| a[1] <=> b[1] })
-      rescue ArgumentError
-        # Non-comparable items
         self
       end
     end

--- a/lib/yaml/sort/list.rb
+++ b/lib/yaml/sort/list.rb
@@ -22,12 +22,13 @@ module Yaml
 
       def to_s
         super + items.map do |item|
-          "#{item[0]}#{item[1]}"
+          "#{item[0]}#{item[1].to_s(skip_first_indent: true)}"
         end.join("\n")
       end
 
       def sort
-        self
+        # TODO: Add an option to sort scalar values
+        List.new(items.map { |i| [i[0], i[1].sort] })
       end
     end
   end

--- a/lib/yaml/sort/parser.ra
+++ b/lib/yaml/sort/parser.ra
@@ -22,7 +22,7 @@ rule
   list: list list_item { val[0].add_item(*val[1]); result = val[0] }
       | list_item      { result = List.create(*val[0]) }
 
-  list_item: ITEM value { result = [Scalar.new(val[0]), val[1]] }
+  list_item: ITEM value { result = [Item.new(val[0]), val[1]] }
 end
 
 ---- header
@@ -94,10 +94,10 @@ def scan(text)
       when s.scan(/\n[[:blank:]]*#.*/)      then emit(:COMMENT, s.matched)
       when s.scan(/\n([[:blank:]]*-) */)    then emit(:ITEM, s.matched, indent: s.captures[0])
       when s.scan(/\n[[:blank:]]*\.\.\./)   then emit(:END_OF_DOCUMENT, s.matched)
-      when s.scan(/\n?([[:blank:]]*)([^[[:space:]]\n]+):(?=[ \n])/)
+      when s.scan(/\n?([[:blank:]]*)([^[[:space:]]\n]+:)(?=[ \n])/)
         indent = s.captures[0]
         indent = last_indent_value + indent + " " unless s.matched.start_with?("\n")
-        emit(:KEY, s.matched, indent: indent)
+        emit(:KEY, s.matched, indent: indent, value: s.captures[1])
 
       when s.scan(/\n\z/)
         # Done
@@ -126,16 +126,16 @@ def scan(text)
   @tokens
 end
 
-def emit(token, value, length: nil, indent: nil)
+def emit(token, match, length: nil, indent: nil, value: nil)
   indent.gsub!("-", " ") if indent
   if token && length.nil?
-    raise "length must be explicitly passed when value is not a String (#{value.class.name})" unless value.is_a?(String)
-    length = value.length
+    raise "length must be explicitly passed when match is not a String (#{match.class.name})" unless match.is_a?(String)
+    length = match.length
   end
 
-  if value.start_with?("\n")
+  if match.start_with?("\n")
     @lineno += 1
-    value = value[1..-1]
+    match = match[1..-1]
     length -= 1
     @position = 0
   end
@@ -146,7 +146,7 @@ def emit(token, value, length: nil, indent: nil)
   end
 
   exvalue = {
-    value: value,
+    value: value || match,
     lineno: @lineno,
     position: @position,
     length: length,
@@ -154,7 +154,7 @@ def emit(token, value, length: nil, indent: nil)
   }
   @tokens << [token, exvalue]
 
-  @lineno += value.count("\n")
+  @lineno += match.count("\n")
 
   @position += length
 end

--- a/lib/yaml/sort/scalar.rb
+++ b/lib/yaml/sort/scalar.rb
@@ -3,12 +3,13 @@
 module Yaml
   module Sort
     class Scalar < Value
-      attr_reader :value
+      attr_reader :value, :indent
 
       def initialize(value)
         super()
         @comment = value[:comment] || []
         @value = value[:value]
+        @indent = value[:indent] || ""
       end
 
       def <=>(other)
@@ -19,8 +20,12 @@ module Yaml
         end
       end
 
-      def to_s
-        super + value
+      def to_s(skip_first_indent: false)
+        if skip_first_indent
+          super + value
+        else
+          super + indent + value
+        end
       end
     end
   end

--- a/lib/yaml/sort/value.rb
+++ b/lib/yaml/sort/value.rb
@@ -7,7 +7,11 @@ module Yaml
         @comment = []
       end
 
-      def to_s
+      def to_s(*)
+        comments
+      end
+
+      def comments
         @comment.join
       end
 


### PR DESCRIPTION
The sorting of lists is incomplete (only scalars are sorted and nested
dictionaries are left untouched).

As reported in #2, such a behavior can lead to unexpected results, so this has
to be changed in a backward incompatible way to have a proper behavior by
default, and maybe then we will want to allow sorting scalars with a flag or
control comments.

Yet, when dictionaries are present in lists, we want to see its items to be
sorted, what does not currently happen.

Fixes #2