### PR TITLE
Fix infinite loops with trailing whitespace

### DIFF
--- a/lib/yaml/sort/parser.ra
+++ b/lib/yaml/sort/parser.ra
@@ -83,6 +83,7 @@ def scan(text)
           emit(:VALUE, match)
         end
       end
+      s.scan(/[[:blank:]]*/)
       scan_value = false
     else
       case


### PR DESCRIPTION
When a file has trailing whitespace, the scanner gets confused and loops
forever refusing te eat that trailing whitespace.
