### PR TITLE
Improve --lint by showing a diff on error

### DIFF
--- a/features/error_reporting.feature
+++ b/features/error_reporting.feature
@@ -11,7 +11,8 @@ Feature: Error reporting
 
       """
     When I run `exe/yaml-sort sample.yaml`
-    Then the stderr should contain:
+    Then the exit status should be 1
+    And the stderr should contain:
       """
       sample.yaml:6 unexpected KEY
       foo: bar
@@ -30,7 +31,8 @@ Feature: Error reporting
       - baz
       """
     When I run `exe/yaml-sort sample.yaml`
-    Then the stderr should contain:
+    Then the exit status should be 1
+    And the stderr should contain:
       """
       sample.yaml:7 unexpected ITEM
       - baz
@@ -47,7 +49,8 @@ Feature: Error reporting
 
       """
     When I run `exe/yaml-sort sample.yaml`
-    Then the stderr should contain:
+    Then the exit status should be 1
+    And the stderr should contain exactly:
       """
       sample.yaml:4 unexpected UNINDENT
       foo:
@@ -64,7 +67,8 @@ Feature: Error reporting
 
       """
     When I run `exe/yaml-sort sample.yaml`
-    Then the stderr should contain:
+    Then the exit status should be 1
+    And the stderr should contain exactly:
       """
       sample.yaml:4 unexpected end-of-file
       """

--- a/features/lint.feature
+++ b/features/lint.feature
@@ -1,0 +1,36 @@
+Feature: Linting YAML files
+  Scenario: When a file is sorted
+    Given a file named "input.yaml" with:
+      """
+      ---
+      bar: bar
+      baz: baz
+      foo: foo
+
+      """
+    When I successfully run `yaml-sort --lint input.yaml`
+    And the output should contain exactly ""
+      
+  Scenario: When a file is not sorted
+    Given a file named "input.yaml" with:
+      """
+      ---
+      foo: foo
+      bar: bar
+      baz: baz
+
+      """
+    When I run `yaml-sort --lint input.yaml`
+    Then the exit status should be 1
+    And the stderr should contain exactly:
+      """
+      diff a/input.yaml b/input.yaml
+      --- a/input.yaml
+      +++ b/input.yaml
+      @@ -1,4 +1,4 @@
+       ---
+      -foo: foo
+       bar: bar
+       baz: baz
+      +foo: foo
+      """


### PR DESCRIPTION
If a file is not sorted the way it is supposed to be sorted, show a diff
of the actual and expected content rather than just saying they don't
match.
