### PR TITLE
Make the Rake tasks silent

### DIFF
--- a/lib/yaml/sort/tasks/puppet.rb
+++ b/lib/yaml/sort/tasks/puppet.rb
@@ -3,11 +3,11 @@
 namespace :lint do
   desc "Check Hiera data content ordering"
   task :hiera_data_ordering do
-    sh "yaml-sort", "--lint", *Dir.glob("data/**/*.yaml")
+    sh "yaml-sort", "--lint", *Dir.glob("data/**/*.yaml"), verbose: false
   end
 end
 
 desc "Reorder Hiera data in-place"
 task :reorder_hiera_data do
-  sh "yaml-sort", "--in-place", *Dir.glob("data/**/*.yaml")
+  sh "yaml-sort", "--in-place", *Dir.glob("data/**/*.yaml"), verbose: false
 end

--- a/lib/yaml/sort/tasks/rails.rb
+++ b/lib/yaml/sort/tasks/rails.rb
@@ -3,11 +3,11 @@
 namespace :test do
   desc "Check translations content ordering"
   task :translations_ordering do
-    sh "yaml-sort", "--lint", *Dir.glob("config/locales/**/*.yml")
+    sh "yaml-sort", "--lint", *Dir.glob("config/locales/**/*.yml"), verbose: false
   end
 end
 
 desc "Reorder translations in-place"
 task :reorder_translations do
-  sh "yaml-sort", "--in-place", *Dir.glob("config/locales/**/*.yml")
+  sh "yaml-sort", "--in-place", *Dir.glob("config/locales/**/*.yml"), verbose: false
 end


### PR DESCRIPTION
The #sh method display the command run by default.  In our case, the
list of files can become distracting so remove this extra information
from the input.
