### PR TITLE
Fix passing-around Aruba FakeKernel

### DIFF
--- a/features/support/aruba.rb
+++ b/features/support/aruba.rb
@@ -11,11 +11,11 @@ class Runner
     $stdin  = stdin
     $stdout = stdout
     $stderr = stderr
-    $kernel = kernel # rubocop:disable Style/GlobalVars
+    @kernel = kernel
   end
 
   def execute!
-    Yaml::Sort::Cli.new.execute(@argv)
+    Yaml::Sort::Cli.new.execute(@argv, @kernel)
   end
 end
 

--- a/lib/yaml/sort/cli.rb
+++ b/lib/yaml/sort/cli.rb
@@ -12,7 +12,7 @@ module Yaml
         @parser = Yaml::Sort::Parser.new
       end
 
-      def execute(argv) # rubocop:disable Metrics/AbcSize, Metrics/MethodLength, Metrics/CyclomaticComplexity, Metrics/PerceivedComplexity
+      def execute(argv, kernel = Kernel) # rubocop:disable Metrics/AbcSize, Metrics/MethodLength, Metrics/CyclomaticComplexity, Metrics/PerceivedComplexity
         options = {
           in_place: false,
           lint: false,
@@ -48,7 +48,7 @@ module Yaml
           end
         end
 
-        $kernel.exit(@exit_code) # rubocop:disable Style/GlobalVars
+        kernel.exit(@exit_code)
       end
 
       def process_document(filename, options)


### PR DESCRIPTION
Fix raised exception when running outside of Aruba:
yaml-sort-2.1.0/lib/yaml/sort/cli.rb:51:in `execute': private method `exit' called for nil:NilClass (NoMethodError)
