### PR TITLE
Add support for &anchor / *alias

### DIFF
--- a/features/error_reporting.feature
+++ b/features/error_reporting.feature
@@ -72,3 +72,21 @@ Feature: Error reporting
       """
       sample.yaml:4 unexpected end-of-file
       """
+  Scenario: Usupported <<: references
+    Given a file named "sample.yaml" with:
+      """
+      ---
+      foo: &ref
+        a: 1
+        b: 2
+      bar:
+        <<: *ref
+      """
+    When I run `exe/yaml-sort sample.yaml`
+    Then the exit status should be 1
+    And the stderr should contain exactly:
+      """
+      sample.yaml:6: '<<:' references are not sortable:
+        <<: *ref
+        ^~~
+      """

--- a/features/sort.feature
+++ b/features/sort.feature
@@ -121,3 +121,49 @@ Feature: Sorting YAML files
       # A single-line comment is attached to the following item
       foo: foo
       """
+  Scenario: Sorting aliases
+    Given a file named "common.yaml" with:
+      """
+      ---
+      def: &alias1
+        a: 1
+        b: &ref 2
+      abc: *alias1
+      jkl: &alias2 "3"
+      ghi: *alias2
+      mno:
+        pqr:
+          vwx:
+            - &ref3 34
+            - *ref
+            - &ref2 23
+            - *ref
+            - *ref3
+          stu: *alias2
+          b: *ref2
+          a: *ref
+          c: *ref2
+      """
+    When I successfully run `exe/yaml-sort common.yaml`
+    Then the stdout should contain:
+      """
+      ---
+      abc: &alias1
+        a: 1
+        b: &ref 2
+      def: *alias1
+      ghi: &alias2 "3"
+      jkl: *alias2
+      mno:
+        pqr:
+          a: *ref
+          b: &ref2 23
+          c: *ref2
+          stu: *alias2
+          vwx:
+            - &ref3 34
+            - *ref
+            - *ref2
+            - *ref
+            - *ref3
+      """

--- a/lib/yaml/sort.rb
+++ b/lib/yaml/sort.rb
@@ -2,6 +2,7 @@
 
 require_relative "sort/parser"
 require_relative "sort/value"
+require_relative "sort/alias"
 require_relative "sort/dictionary"
 require_relative "sort/item"
 require_relative "sort/list"

--- a/lib/yaml/sort/alias.rb
+++ b/lib/yaml/sort/alias.rb
@@ -1,0 +1,39 @@
+# frozen_string_literal: true
+
+module Yaml
+  module Sort
+    class Alias < Value
+      attr_reader :name
+
+      def initialize(anchors, name)
+        super()
+        @anchors = anchors
+        @name = name[:value]
+      end
+
+      def value?
+        @anchors[@name]
+      end
+
+      def delete_value
+        @anchors.delete(@name)
+      end
+
+      def to_s(*)
+        if (s = @anchors.delete(@name))
+          separator = case s
+                      when List, Dictionary then "\n"
+                      else " "
+                      end
+          "&#{name}#{separator}#{s}"
+        else
+          "*#{name}"
+        end
+      end
+
+      def <=>(_other)
+        0
+      end
+    end
+  end
+end

--- a/lib/yaml/sort/dictionary.rb
+++ b/lib/yaml/sort/dictionary.rb
@@ -25,10 +25,9 @@ module Yaml
         super + items.map do |k, v|
           n += 1
           case v
-          when List, Dictionary
-            "#{k.to_s(skip_first_indent: skip_first_indent && n.zero?)}\n#{v}"
-          when Scalar
-            "#{k.to_s(skip_first_indent: skip_first_indent && n.zero?)} #{v}"
+          when List, Dictionary then "#{k.to_s(skip_first_indent: skip_first_indent && n.zero?)}\n#{v}"
+          when Scalar, Alias    then "#{k.to_s(skip_first_indent: skip_first_indent && n.zero?)} #{v}"
+          else raise "Unexpected type"
           end
         end.join("\n")
       end

--- a/lib/yaml/sort/parser.ra
+++ b/lib/yaml/sort/parser.ra
@@ -5,7 +5,7 @@
 class Yaml::Sort::Parser
 token
   START_OF_DOCUMENT END_OF_DOCUMENT
-  VALUE KEY UNINDENT ITEM
+  VALUE KEY UNINDENT ITEM ANCHOR ALIAS
 rule
   document: START_OF_DOCUMENT value END_OF_DOCUMENT { result = val[1] }
           | START_OF_DOCUMENT value                 { result = val[1] }
@@ -13,16 +13,19 @@ rule
   value: VALUE               { result = Scalar.new(val[0]) }
        | dictionary UNINDENT { result = val[0] }
        | list UNINDENT       { result = val[0] }
+       | ALIAS               { result = Alias.new(@anchors, val[0]) }
 
   dictionary: dictionary dictionary_item { val[0].add_item(*val[1]); result = val[0] }
             | dictionary_item            { result = Dictionary.create(*val[0]) }
 
-  dictionary_item: KEY value { result = [Scalar.new(val[0]), val[1]] }
+  dictionary_item: KEY ANCHOR value { @anchors[val[1][:value]] = val[2]; result = [Scalar.new(val[0]), Alias.new(@anchors, val[1])] }
+                 | KEY value        { result = [Scalar.new(val[0]), val[1]] }
 
   list: list list_item { val[0].add_item(*val[1]); result = val[0] }
       | list_item      { result = List.create(*val[0]) }
 
-  list_item: ITEM value { result = [Item.new(val[0]), val[1]] }
+  list_item: ITEM ANCHOR value { @anchors[val[1][:value]] = val[2]; result = [Item.new(val[0]),  Alias.new(@anchors, val[1])] }
+           | ITEM value        { result = [Item.new(val[0]), val[1]] }
 end
 
 ---- header
@@ -43,11 +46,16 @@ def scan(text)
   @fakelineno = 0
   @position = 0
   @indent_stack = []
+  @anchors = {}
 
   until s.eos?
     if scan_value
       @position += s.matched_size if s.scan(/[[:blank:]]*/)
       case
+      when s.scan(/&[[:alnum:]]+/)
+        emit(:ANCHOR, s.matched[1..-1])
+      when s.scan(/\*[[:alnum:]]+/)
+        emit(:ALIAS, s.matched[1..-1])
       when s.scan(/[|>][-+]?(?=\n)/)
         match = s.matched
 

--- a/lib/yaml/sort/parser.ra
+++ b/lib/yaml/sort/parser.ra
@@ -165,8 +165,19 @@ def emit(token, match, length: nil, indent: nil, value: nil)
     @indent_stack.push(indent) unless @indent_stack.last == indent
   end
 
+  value ||= match
+
+  if token == :KEY && value == '<<:'
+    message = <<~MESSAGE
+      #{@filename}:#{@lineno}: '<<:' references are not sortable:
+      #{@lines[@lineno - 1].chomp}
+      #{indent}#{" " * @position}^#{"~" * (length - indent.length - 1)}
+    MESSAGE
+    raise(Racc::ParseError, message)
+  end
+
   exvalue = {
-    value: value || match,
+    value: value,
     lineno: @lineno,
     position: @position,
     length: length,


### PR DESCRIPTION
YAML provides node anchors (using `&`) and aliases (using `*`) to reuse
portion of a document.

When reading an anchor, store the actual data and act like an alias was
found.  When writing the document, output the actual data as an anchor
when the first alias is found, and output on alias for the next
occurences.
