### PR TITLE
Fix relocation of comments following UNINDENT

### DIFF
--- a/features/sort.feature
+++ b/features/sort.feature
@@ -104,14 +104,24 @@ Feature: Sorting YAML files
         # Multi
         # line
         - bar
+      bat:
+        foo: foo
+        bar: bar
+      # Another comment after indentation
+      bak: bak
       """
     When I successfully run `exe/yaml-sort common.yaml`
     Then the stdout should contain:
       """
       ---
+      # Another comment after indentation
+      bak: bak
       # A multi-line comment is attached to the following item
       # (Just like a single-line comment)
       bar: bar
+      bat:
+        bar: bar
+        foo: foo
       baz:
         # Single line
         - foo

--- a/lib/yaml/sort/parser.ra
+++ b/lib/yaml/sort/parser.ra
@@ -135,7 +135,7 @@ def scan(text)
   @tokens.each do |token|
     if token[0] == :COMMENT
       comment << token[1][:value] + "\n"
-    elsif comment.any?
+    elsif comment.any? && token[0] != :UNINDENT
       token[1][:comment] = comment
       comment = []
     end


### PR DESCRIPTION
Comments after an UNINDENT token are lost.  They should be attached to the next
token in order to be ordered as expected.
