### PR TITLE
Fix parsing of dictionaries with quotes in KEY/VALUE

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -13,7 +13,7 @@ jobs:
   rubocop:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Setup ruby
         uses: ruby/setup-ruby@v1
         with:
@@ -30,9 +30,10 @@ jobs:
           - "2.7"
           - "3.0"
           - "3.1"
+          - "3.2"
     name: Ruby ${{ matrix.ruby }}
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Setup ruby
         uses: ruby/setup-ruby@v1
         with:

--- a/lib/yaml/sort/parser.ra
+++ b/lib/yaml/sort/parser.ra
@@ -101,10 +101,11 @@ def scan(text)
       when s.scan(/\n[[:blank:]]*#.*/)      then emit(:COMMENT, s.matched)
       when s.scan(/\n([[:blank:]]*-) */)    then emit(:ITEM, s.matched, indent: s.captures[0])
       when s.scan(/\n[[:blank:]]*\.\.\./)   then emit(:END_OF_DOCUMENT, s.matched)
-      when s.scan(/\n?([[:blank:]]*)(.+:)(?=[ \n])/)
+      when s.scan(/\n?([[:blank:]]*)(.+?:)(?=[ \n])/)
         indent = s.captures[0]
         indent = last_indent_value + indent + " " unless s.matched.start_with?("\n")
         emit(:KEY, s.matched, indent: indent, value: s.captures[1])
+        scan_value = true if s.rest
 
       when s.scan(/\n\z/)
         # Done

--- a/spec/yaml/sort_parser_spec.rb
+++ b/spec/yaml/sort_parser_spec.rb
@@ -15,6 +15,8 @@ RSpec.describe Yaml::Sort::Parser do
         bar: |-
           Plop
         baz biz: 42
+        qux: 'quux: quuux'
+        ta'ata: mā'ohi
       YAML
     end
 
@@ -28,7 +30,11 @@ RSpec.describe Yaml::Sort::Parser do
                          [:VALUE, { length: 9, lineno: 3, position: 5, value: "|-\n  Plop", indent: nil }],
                          [:KEY, { length: 8, lineno: 5, position: 0, value: "baz biz:", indent: "" }],
                          [:VALUE, { length: 2, lineno: 5, position: 9, value: "42", indent: nil }],
-                         [:UNINDENT, { length: 0, lineno: 5, position: 0, value: "", indent: nil }]])
+                         [:KEY, { length: 4, lineno: 6, position: 0, value: "qux:", indent: "" }],
+                         [:VALUE, { length: 13, lineno: 6, position: 5, value: "'quux: quuux'", indent: nil }],
+                         [:KEY, { length: 7, lineno: 7, position: 0, value: "ta'ata:", indent: "" }],
+                         [:VALUE, { length: 6, lineno: 7, position: 8, value: "mā'ohi", indent: nil }],
+                         [:UNINDENT, { length: 0, lineno: 7, position: 0, value: "", indent: nil }]])
     end
   end
 


### PR DESCRIPTION
Dictionaries with VALUES that looks-like a KEY are not scanned correctly:

```
foo: "bar: baz"
^~~~~~~~~~ ^~~
KEY        VALUE
```

In this case, the read VALUE is malformed, and yaml-sort raise an exception (#20).

Fixes #20
