### PR TITLE
Fix parsing of "simple" multi-line VALUE

### DIFF
--- a/lib/yaml/sort/parser.ra
+++ b/lib/yaml/sort/parser.ra
@@ -82,10 +82,11 @@ def scan(text)
           match += s.scan(/'/)
         end
         emit(:VALUE, match)
-      when s.scan(/\S+/)
-        match = s.matched
-        until s.match?(/[\n]/) || s.eos?
-          match += s.scan(/[^\n]+/)
+      when s.match?(/\S+/)
+        match = s.scan_until(/$/)
+
+        while s.match?("\n" + last_indent_value + " ")
+          match += s.scan(/\n[^\n]+(?=\n)/)
         end
         emit(:VALUE, match)
       end

--- a/spec/yaml/sort_parser_spec.rb
+++ b/spec/yaml/sort_parser_spec.rb
@@ -17,6 +17,9 @@ RSpec.describe Yaml::Sort::Parser do
         baz biz: 42
         qux: 'quux: quuux'
         ta'ata: mā'ohi
+        multi-line: starts here
+          continues
+          and end there
       YAML
     end
 
@@ -34,7 +37,9 @@ RSpec.describe Yaml::Sort::Parser do
                          [:VALUE, { length: 13, lineno: 6, position: 5, value: "'quux: quuux'", indent: nil }],
                          [:KEY, { length: 7, lineno: 7, position: 0, value: "ta'ata:", indent: "" }],
                          [:VALUE, { length: 6, lineno: 7, position: 8, value: "mā'ohi", indent: nil }],
-                         [:UNINDENT, { length: 0, lineno: 7, position: 0, value: "", indent: nil }]])
+                         [:KEY, { length: 11, lineno: 8, position: 0, value: "multi-line:", indent: "" }],
+                         [:VALUE, { length: 39, lineno: 8, position: 12, value: "starts here\n  continues\n  and end there", indent: nil }],
+                         [:UNINDENT, { length: 0, lineno: 10, position: 0, value: "", indent: nil }]])
     end
   end
 


### PR DESCRIPTION
A VALUE can continue on the next line if it is further indented:

```yaml
foo: bar
  baz
```

`yaml-sort` fails to scan this syntax correctly: after reading a KEY (`foo:`) and a VALUE (`bar`) it chokes on unexpected content:

```
  baz
^~~~~
```

Fixes: #23
