### PR TITLE
Fix parsing of lists with empty values

### DIFF
--- a/features/sort.feature
+++ b/features/sort.feature
@@ -131,6 +131,38 @@ Feature: Sorting YAML files
       # A single-line comment is attached to the following item
       foo: foo
       """
+  Scenario: Dealing with empty items
+    Given a file named "common.yaml" with:
+      """
+      test:
+        day_names:
+        - domenica
+        - lunedì
+        abbr_month_names:
+        -
+        - gen
+        -
+        -
+        -
+        - feb
+        -
+      """
+    When I successfully run `exe/yaml-sort common.yaml`
+    Then the stdout should contain:
+      """
+      test:
+        abbr_month_names:
+        -
+        - gen
+        -
+        -
+        -
+        - feb
+        -
+        day_names:
+        - domenica
+        - lunedì
+      """
   Scenario: Sorting aliases
     Given a file named "common.yaml" with:
       """

--- a/lib/yaml/sort/parser.ra
+++ b/lib/yaml/sort/parser.ra
@@ -6,6 +6,9 @@ class Yaml::Sort::Parser
 token
   START_OF_DOCUMENT END_OF_DOCUMENT
   VALUE KEY UNINDENT ITEM ANCHOR ALIAS
+prechigh
+  left ITEM
+preclow
 rule
   document: START_OF_DOCUMENT value END_OF_DOCUMENT { result = val[1] }
           | START_OF_DOCUMENT value                 { result = val[1] }
@@ -26,6 +29,7 @@ rule
 
   list_item: ITEM ANCHOR value { @anchors[val[1][:value]] = val[2]; result = [Item.new(val[0]),  Alias.new(@anchors, val[1])] }
            | ITEM value        { result = [Item.new(val[0]), val[1]] }
+           | ITEM              { result = [Item.new(val[0]), Scalar.new({value: ''})] }
 end
 
 ---- header


### PR DESCRIPTION
Empty list items cause trouble.  When an ITEM is not followed by a VALUE in a list item, it should be considered as an item with an empty value.

Fixes: #29 