### PR TITLE
Fix sorting dictionaries when they have an anchor

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -5,9 +5,13 @@ source "https://rubygems.org"
 # Specify your gem's dependencies in yaml-sort.gemspec
 gemspec
 
+gem "racc"
 gem "rake", "~> 13.0"
 
+gem "aruba"
 gem "rspec", "~> 3.0"
+
+gem "github_changelog_generator"
 
 gem "rubocop", "~> 1.21"
 gem "rubocop-rake"

--- a/features/sort.feature
+++ b/features/sort.feature
@@ -168,8 +168,8 @@ Feature: Sorting YAML files
       """
       ---
       def: &alias1
-        a: 1
         b: &ref 2
+        a: 1
       abc: *alias1
       jkl: &alias2 "3"
       ghi: *alias2

--- a/lib/yaml/sort/cli.rb
+++ b/lib/yaml/sort/cli.rb
@@ -70,6 +70,7 @@ module Yaml
 
       def sort_yaml(yaml, filename)
         document = @parser.parse(yaml, filename: filename)
+        @parser.sort_anchors!
         document = document.sort
         "---\n#{document}\n"
       end

--- a/lib/yaml/sort/parser.ra
+++ b/lib/yaml/sort/parser.ra
@@ -223,3 +223,7 @@ def on_error(error_token_id, error_value, value_stack)
 
   raise(Racc::ParseError, message)
 end
+
+def sort_anchors!
+  @anchors.transform_values!(&:sort)
+end

--- a/yaml-sort.gemspec
+++ b/yaml-sort.gemspec
@@ -30,8 +30,4 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
 
   spec.add_dependency "cri"
-
-  spec.add_development_dependency "aruba"
-  spec.add_development_dependency "github_changelog_generator"
-  spec.add_development_dependency "racc"
 end


### PR DESCRIPTION
A dictionary with an anchor should be sorted similarly to a simple dictionary:

```yaml
a: &a
  x: 1
  z: 2
  y: 3
```

should be sorted as:

```yaml
a: &a
  x: 1
  y: 3
  z: 2
```